### PR TITLE
Add `files` to `package.json`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "dom",
     "symbol"
   ],
+  "files": ["lib"],
   "author": "Joris van der Wel <joris@jorisvanderwel.com>",
   "license": "MIT",
   "bugs": {


### PR DESCRIPTION
Prevents `test` and `.jscsrc` from being published to NPM.