### PR TITLE
Hotfix of remove method

### DIFF
--- a/lib/SymbolTree.js
+++ b/lib/SymbolTree.js
@@ -669,6 +669,8 @@ class SymbolTree {
                 removeNode.parent = null;
                 removeNode.previousSibling = null;
                 removeNode.nextSibling = null;
+                removeNode.cachedIndex = -1;
+                removeNode.cachedIndexVersion = NaN;                
 
                 if (parentNode) {
                         parentNode.childrenChanged();


### PR DESCRIPTION
Rare bug could happen when removing and linking element back to tree in index method. Index method was returning cached value instead of recomputing the index if the element had previously same cachedIndexVersion as new parent had childrenVersion. In this fix we are purging cachedIndexVersion in remove method as removed elements dont belong to any children collection anyway.