### PR TITLE
Hotfix of remove method

### DIFF
--- a/lib/SymbolTree.js
+++ b/lib/SymbolTree.js
@@ -669,6 +669,8 @@ class SymbolTree {
                 removeNode.parent = null;
                 removeNode.previousSibling = null;
                 removeNode.nextSibling = null;
+                removeNode.cachedIndex = -1;
+                removeNode.cachedIndexVersion = NaN;
 
                 if (parentNode) {
                         parentNode.childrenChanged();

--- a/test/SymbolTree.js
+++ b/test/SymbolTree.js
@@ -1129,11 +1129,11 @@ test('cached index purge', (t) => {
         tree.appendChild(a, aa);
         tree.appendChild(b, ba);
         tree.appendChild(b, bb);
-  
+
         t.equal(0, tree.index(ba));
         tree.remove(ba);
         t.equal(-1, tree.index(ba));
-        tree.appendChild(a,ba);
+        tree.appendChild(a, ba);
         t.equal(1, tree.index(ba));
 
         t.end();

--- a/test/SymbolTree.js
+++ b/test/SymbolTree.js
@@ -739,7 +739,6 @@ test('children iterator reverse', (t) => {
         t.end();
 });
 
-
 test('children iterator return value using a generator', (t) => {
         const tree = new SymbolTree();
         const a = o();
@@ -1118,7 +1117,6 @@ test('cached index warmed up by childrenToArray', (t) => {
 
         t.end();
 });
-
 
 test('cached index purge', (t) => {
         const tree = new SymbolTree();

--- a/test/SymbolTree.js
+++ b/test/SymbolTree.js
@@ -1119,6 +1119,28 @@ test('cached index warmed up by childrenToArray', (t) => {
         t.end();
 });
 
+
+test('cached index purge', (t) => {
+        const tree = new SymbolTree();
+        const a = o();
+        const aa = o();
+        const b = o();
+        const ba = o();
+        const bb = o();
+
+        tree.appendChild(a, aa);
+        tree.appendChild(b, ba);
+        tree.appendChild(b, bb);
+  
+        t.equal(0, tree.index(ba));
+        tree.remove(ba);
+        t.equal(-1, tree.index(ba));
+        tree.appendChild(a,ba);
+        t.equal(1, tree.index(ba));
+
+        t.end();
+});
+
 test('children count', (t) => {
         // no need to test the caching since we already tested for that in childrenCount
         const tree = new SymbolTree();


### PR DESCRIPTION
Rare bug could happen when removing and linking element back to tree in index method. Index method was returning cached value instead of recomputing the index if the element had previously same cachedIndexVersion as new parent had childrenVersion. In this fix we are purging cachedIndexVersion in remove method as removed elements dont belong to any children collection anyway.