### PR TITLE
docs: Fix JSDoc type information

### DIFF
--- a/lib/SymbolTree.js
+++ b/lib/SymbolTree.js
@@ -33,7 +33,7 @@ class SymbolTree {
          * to take advantage of V8's fast properties. Also useful if you would like to
          * freeze your object.
          *
-         * `O(1)`
+         * * `O(1)`
          *
          * @method
          * @alias module:symbol-tree#initialize
@@ -444,7 +444,7 @@ class SymbolTree {
          * @method treeIterator
          * @memberOf module:symbol-tree#
          * @param {Object} root
-         * @param {Object} options
+         * @param {Object} [options]
          * @param {Boolean} [options.reverse=false]
          * @return {Object} An iterable iterator (ES6)
          */


### PR DESCRIPTION
The&nbsp;`options`&nbsp;parameter in&nbsp;`SymbolTree.treeIterator(…)`  is&nbsp;optional and&nbsp;used&nbsp;as&nbsp;such in&nbsp;**JSDOM**.